### PR TITLE
Fixed deprecated numpy type

### DIFF
--- a/maskcut/crf.py
+++ b/maskcut/crf.py
@@ -18,7 +18,7 @@ Bi_RGB_STD = 5
 def densecrf(image, mask):
     h, w = mask.shape
     mask = mask.reshape(1, h, w)
-    fg = mask.astype(np.float) 
+    fg = mask.astype(float) 
     bg = 1 - fg
     output_logits = torch.from_numpy(np.concatenate((bg,fg), axis=0))
 


### PR DESCRIPTION
When installing the dependencies a newer version of numpy is installed, leading to an attribute error when running the Demo.

Just a quick fix to alleviate the problem and make it compatible with all version of numpy.